### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 python-linkat
 =============
 
-.. image:: https://pypip.in/version/linkat/badge.png
+.. image:: https://img.shields.io/pypi/v/linkat.svg
     :target: https://pypi.python.org/pypi/linkat/
     :alt: Latest Version
 
-.. image:: https://pypip.in/license/linkat/badge.png
+.. image:: https://img.shields.io/pypi/l/linkat.svg
     :target: https://pypi.python.org/pypi/linkat/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20linkat))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `linkat`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.